### PR TITLE
Add various repeater fixes

### DIFF
--- a/src/main/java/com/rikaisan/mixin/BlockLogicRepeaterMixin.java
+++ b/src/main/java/com/rikaisan/mixin/BlockLogicRepeaterMixin.java
@@ -2,8 +2,11 @@ package com.rikaisan.mixin;
 
 import net.minecraft.core.block.Block;
 import net.minecraft.core.block.BlockLogic;
+import net.minecraft.core.block.BlockLogicBed;
 import net.minecraft.core.block.BlockLogicRepeater;
 import net.minecraft.core.block.material.Material;
+import net.minecraft.core.util.helper.Side;
+import net.minecraft.core.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 
 @Mixin(BlockLogicRepeater.class)
@@ -15,5 +18,12 @@ public abstract class BlockLogicRepeaterMixin extends BlockLogic {
 	@Override
 	public boolean isSignalSource() {
 		return true;
+	}
+	// Cause block updates on the target block when removing a repeater,
+	// which prevents redstone components on the other wide of the target block from staying powered.
+	@Override
+	public void onBlockRemoved(World world, int x, int y, int z, int data) {
+		Side facing = BlockLogicBed.headBlockToFootBlockMap[BlockLogicBed.footToHeadMap[data & 3]];
+		world.notifyBlocksOfNeighborChange(x + facing.getOffsetX(), y + facing.getOffsetY(), z + facing.getOffsetZ(), id());
 	}
 }

--- a/src/main/java/com/rikaisan/mixin/BlockLogicRepeaterMixin.java
+++ b/src/main/java/com/rikaisan/mixin/BlockLogicRepeaterMixin.java
@@ -1,0 +1,19 @@
+package com.rikaisan.mixin;
+
+import net.minecraft.core.block.Block;
+import net.minecraft.core.block.BlockLogic;
+import net.minecraft.core.block.BlockLogicRepeater;
+import net.minecraft.core.block.material.Material;
+import org.spongepowered.asm.mixin.Mixin;
+
+@Mixin(BlockLogicRepeater.class)
+public abstract class BlockLogicRepeaterMixin extends BlockLogic {
+	public BlockLogicRepeaterMixin(Block<?> block, Material material) {
+		super(block, material);
+	}
+	// Ensure that repeaters can activate doors, tnt, and other redstone components through powering a neighboring block.
+	@Override
+	public boolean isSignalSource() {
+		return true;
+	}
+}

--- a/src/main/java/com/rikaisan/mixin/BlockLogicWireRedstoneMixin.java
+++ b/src/main/java/com/rikaisan/mixin/BlockLogicWireRedstoneMixin.java
@@ -1,13 +1,20 @@
 package com.rikaisan.mixin;
 
 import com.rikaisan.AdditionalRedstoneWireLogic;
+import net.minecraft.core.block.Block;
+import net.minecraft.core.block.BlockLogicBed;
 import net.minecraft.core.block.BlockLogicWireRedstone;
+import net.minecraft.core.block.Blocks;
 import net.minecraft.core.util.helper.Axis;
 import net.minecraft.core.util.helper.Side;
 import net.minecraft.core.world.WorldSource;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import static net.minecraft.core.block.BlockLogicWireRedstone.shouldConnectTo;
 
@@ -70,5 +77,22 @@ public abstract class BlockLogicWireRedstoneMixin {
 			|| side == Side.WEST && negXShouldConnectTo && !isZConnected
 			|| side == Side.EAST && posXShouldConnectTo && !isZConnected;
 		}
+	}
+	// Connect to both the front and back of the repeater, instead of only the back.
+	@Inject(method = "shouldConnectTo", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/world/WorldSource;getBlockMetadata(III)I", ordinal = 1), cancellable = true)
+	private static void connectToFrontBackRepeater(WorldSource worldSource, int x, int y, int z, int data, CallbackInfoReturnable<Boolean> cir) {
+		// Get the requested side.
+		Side source = BlockLogicBed.headBlockToFootBlockMap[BlockLogicBed.footToHeadMap[data]];
+		// Get the side the repeater is facing.
+		Side target = BlockLogicBed.headBlockToFootBlockMap[worldSource.getBlockMetadata(x, y, z) & 3];
+		cir.setReturnValue(target == source || target == source.getOpposite());
+	}
+
+	// Required for setting the repeater to be a signal source.
+	// Otherwise, connectToFrontBackRepeater will not be called, and redstone will redirect to all sides of the repeater.
+	@Redirect(method = "shouldConnectTo", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/block/Block;isSignalSource()Z"))
+	private static boolean dontConnectToAllRepeaterSides(Block<?> instance) {
+		if(instance == Blocks.REPEATER_IDLE || instance == Blocks.REPEATER_ACTIVE) return false;
+		return instance.isSignalSource();
 	}
 }

--- a/src/main/java/com/rikaisan/mixin/WorldMixin.java
+++ b/src/main/java/com/rikaisan/mixin/WorldMixin.java
@@ -8,6 +8,7 @@ import net.minecraft.core.world.WorldSource;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 
 @Mixin(value = World.class, remap = false)
 public abstract class WorldMixin {
@@ -22,11 +23,23 @@ public abstract class WorldMixin {
 		if (this.isBlockNormalCube(x, y, z) && block != Blocks.BLOCK_REDSTONE && block != Blocks.PUMPKIN_REDSTONE) {
 			return this.hasDirectSignal(x, y, z);
 		} else if (block == Blocks.PUMPKIN_REDSTONE) { // Patch to make the redstone pumpkin behave like a solid block
-			return this.hasDirectSignal(x, y, z) || block.getSignal((WorldSource) this, x, y, z, side);
+			return pumpkinHasDirectSignal(x, y, z) || block.getSignal((WorldSource) this, x, y, z, side);
 		}
 		else {
 			return block != null && block.getSignal((WorldSource) this, x, y, z, side);
 		}
+	}
+	// Special version of hasDirectSignal that excludes the front side of the redstone lantern.
+	@Unique
+	private boolean pumpkinHasDirectSignal(int x, int y, int z) {
+		for (Side side : Side.sides) {
+			if(Side.getSideById(getBlockMetadata(x, y, z)) == side) continue;
+			if (getDirectSignal(x + side.getOffsetX(), y + side.getOffsetY(), z + side.getOffsetZ(), side)) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	@Shadow
@@ -37,5 +50,11 @@ public abstract class WorldMixin {
 
 	@Shadow
 	public abstract Block<?> getBlock(int x, int y, int z);
+
+	@Shadow
+	public abstract boolean getDirectSignal(int x, int y, int z, Side side);
+
+	@Shadow
+	public abstract int getBlockMetadata(int x, int y, int z);
 }
 

--- a/src/main/resources/redstonetweaks.mixins.json
+++ b/src/main/resources/redstonetweaks.mixins.json
@@ -5,6 +5,7 @@
   "compatibilityLevel": "JAVA_8",
   "mixins": [
     "BlockLogicRedstoneMixin",
+    "BlockLogicRepeaterMixin",
     "BlockLogicWireRedstoneMixin",
     "WorldMixin"
   ],


### PR DESCRIPTION
Add repeater fixes for soft powering tnt and doors through a neighbouring blocks, as well as redirecting redstone from both front and back.