### PR TITLE
Improve support for mixins from other mods

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,6 +88,8 @@ dependencies {
 	modRuntimeOnly "objects:client:43db9b498cb67058d2e12d394e6507722e71bb45" // https://piston-data.mojang.com/v1/objects/43db9b498cb67058d2e12d394e6507722e71bb45/client.jar
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
+	include(implementation(annotationProcessor("io.github.llamalad7:mixinextras-fabric:0.5.0-beta.5")))
+
 	// Helper library
 	// If you do not need Halplibe you can comment this line out or delete this line
 	implementation("turniplabs:halplibe:${project.halplibe_version}")

--- a/src/main/java/com/rikaisan/mixin/BlockLogicRedstoneMixin.java
+++ b/src/main/java/com/rikaisan/mixin/BlockLogicRedstoneMixin.java
@@ -1,19 +1,19 @@
 package com.rikaisan.mixin;
 
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.rikaisan.RedstoneTweaks;
 import net.minecraft.core.block.BlockLogicRedstone;
 import net.minecraft.core.util.helper.Side;
 import net.minecraft.core.world.World;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(value = BlockLogicRedstone.class, remap = false)
 public abstract class BlockLogicRedstoneMixin {
 
-	@Inject(method = "getDirectSignal(Lnet/minecraft/core/world/World;IIILnet/minecraft/core/util/helper/Side;)Z", at = @At("RETURN"), cancellable = true)
-	public void getDirectSignal(World world, int x, int y, int z, Side side, CallbackInfoReturnable<Boolean> cir) {
-		cir.setReturnValue(world.getGameRuleValue(RedstoneTweaks.REDSTONE_BLOCK_HARD_POWER));
+	@WrapMethod(method = "getDirectSignal(Lnet/minecraft/core/world/World;IIILnet/minecraft/core/util/helper/Side;)Z")
+	public boolean getDirectSignal(World world, int x, int y, int z, Side side, Operation<Boolean> original) {
+		if(world.getGameRuleValue(RedstoneTweaks.REDSTONE_BLOCK_HARD_POWER)) return original.call(world, x, y, z, side);
+		return false;
 	}
 }

--- a/src/main/java/com/rikaisan/mixin/BlockLogicRedstoneMixin.java
+++ b/src/main/java/com/rikaisan/mixin/BlockLogicRedstoneMixin.java
@@ -11,6 +11,7 @@ import org.spongepowered.asm.mixin.Mixin;
 @Mixin(value = BlockLogicRedstone.class, remap = false)
 public abstract class BlockLogicRedstoneMixin {
 
+	/// Make redstone blocks weak power instead of strong power, unless the relevant gamerule is set.
 	@WrapMethod(method = "getDirectSignal(Lnet/minecraft/core/world/World;IIILnet/minecraft/core/util/helper/Side;)Z")
 	public boolean getDirectSignal(World world, int x, int y, int z, Side side, Operation<Boolean> original) {
 		if(world.getGameRuleValue(RedstoneTweaks.REDSTONE_BLOCK_HARD_POWER)) return original.call(world, x, y, z, side);

--- a/src/main/java/com/rikaisan/mixin/BlockLogicWireRedstoneMixin.java
+++ b/src/main/java/com/rikaisan/mixin/BlockLogicWireRedstoneMixin.java
@@ -19,7 +19,6 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-@Debug(export = true)
 @Mixin(value = BlockLogicWireRedstone.class, remap = false)
 public abstract class BlockLogicWireRedstoneMixin {
 

--- a/src/main/java/com/rikaisan/mixin/BlockLogicWireRedstoneMixin.java
+++ b/src/main/java/com/rikaisan/mixin/BlockLogicWireRedstoneMixin.java
@@ -32,7 +32,7 @@ public abstract class BlockLogicWireRedstoneMixin {
 
 	@Definition(id = "negZShouldConnectTo", local = @Local(type = boolean.class, name = "negZShouldConnectTo"))
 	@Expression("negZShouldConnectTo")
-	@Inject(method = "getSignal", at = @At("MIXINEXTRAS:EXPRESSION"), cancellable = true)
+	@Inject(method = "getSignal", at = @At(value = "MIXINEXTRAS:EXPRESSION", ordinal = 0), cancellable = true)
 	private void fixRedirections(WorldSource worldSource, int x, int y, int z, Side side, CallbackInfoReturnable<Boolean> cir, @Local(name = "posXShouldConnectTo") boolean posXShouldConnectTo, @Local(name = "negXShouldConnectTo") boolean negXShouldConnectTo, @Local(name = "posZShouldConnectTo") boolean posZShouldConnectTo, @Local(name = "negZShouldConnectTo") boolean negZShouldConnectTo) {
 		boolean isXConnected = posXShouldConnectTo || negXShouldConnectTo;
 		boolean isZConnected = posZShouldConnectTo || negZShouldConnectTo;

--- a/src/main/java/com/rikaisan/mixin/BlockLogicWireRedstoneMixin.java
+++ b/src/main/java/com/rikaisan/mixin/BlockLogicWireRedstoneMixin.java
@@ -1,5 +1,10 @@
 package com.rikaisan.mixin;
 
+import com.llamalad7.mixinextras.expression.Definition;
+import com.llamalad7.mixinextras.expression.Expression;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
 import com.rikaisan.AdditionalRedstoneWireLogic;
 import net.minecraft.core.block.Block;
 import net.minecraft.core.block.BlockLogicBed;
@@ -9,63 +14,31 @@ import net.minecraft.core.util.helper.Axis;
 import net.minecraft.core.util.helper.Side;
 import net.minecraft.core.world.WorldSource;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Overwrite;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import static net.minecraft.core.block.BlockLogicWireRedstone.shouldConnectTo;
-
 @Mixin(value = BlockLogicWireRedstone.class, remap = false)
 public abstract class BlockLogicWireRedstoneMixin {
-	@Shadow
-	private boolean shouldSignal;
 
-	/**
-	 * @author Rikai
-	 * @reason Refactor + fix redirection logic. Couldn't manage to inject the return and honestly don't want anyone to mess with this logic.
-	 */
-	@Overwrite
-	public boolean getSignal(WorldSource worldSource, int x, int y, int z, Side side) {
-		if (!this.shouldSignal || worldSource.getBlockMetadata(x, y, z) == 0) {
-			return false;
-		} else if (side == Side.TOP) {
-			return true;
-		} else {
-			boolean negXShouldConnectTo = shouldConnectTo(worldSource, x - 1, y, z, 1)
-				|| !worldSource.isBlockNormalCube(x - 1, y, z) && AdditionalRedstoneWireLogic.shouldConnectToDiagonal(worldSource, x - 1, y - 1, z, -1, Side.TOP);
-			boolean posXShouldConnectTo = shouldConnectTo(worldSource, x + 1, y, z, 3)
-				|| !worldSource.isBlockNormalCube(x + 1, y, z) && AdditionalRedstoneWireLogic.shouldConnectToDiagonal(worldSource, x + 1, y - 1, z, -1, Side.TOP);
-			boolean negZShouldConnectTo = shouldConnectTo(worldSource, x, y, z - 1, 2)
-				|| !worldSource.isBlockNormalCube(x, y, z - 1) && AdditionalRedstoneWireLogic.shouldConnectToDiagonal(worldSource, x, y - 1, z - 1, -1, Side.TOP);
-			boolean posZShouldConnectTo = shouldConnectTo(worldSource, x, y, z + 1, 0)
-				|| !worldSource.isBlockNormalCube(x, y, z + 1) && AdditionalRedstoneWireLogic.shouldConnectToDiagonal(worldSource, x, y - 1, z + 1, -1, Side.TOP);
 
-			if (!worldSource.isBlockNormalCube(x, y + 1, z)) {
-				if (worldSource.isBlockNormalCube(x - 1, y, z) && AdditionalRedstoneWireLogic.shouldConnectToDiagonal(worldSource, x - 1, y + 1, z, -1, Side.BOTTOM)) {
-					negXShouldConnectTo = true;
-				}
+	@WrapOperation(method = "getSignal", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/block/BlockLogicWireRedstone;shouldConnectTo(Lnet/minecraft/core/world/WorldSource;IIII)Z"))
+	private boolean fixDiagonal(WorldSource worldSource, int x, int y, int z, int data, Operation<Boolean> original, @Local(name = "y") int originalY) {
+		if(y == originalY - 1) return AdditionalRedstoneWireLogic.shouldConnectToDiagonal(worldSource, x, y, z, data, Side.TOP);
+		if(y == originalY + 1) return AdditionalRedstoneWireLogic.shouldConnectToDiagonal(worldSource, x, y, z, data, Side.BOTTOM);
+		return original.call(worldSource, x, y, z, data);
+	}
 
-				if (worldSource.isBlockNormalCube(x + 1, y, z) && AdditionalRedstoneWireLogic.shouldConnectToDiagonal(worldSource, x + 1, y + 1, z, -1, Side.BOTTOM)) {
-					posXShouldConnectTo = true;
-				}
-
-				if (worldSource.isBlockNormalCube(x, y, z - 1) && AdditionalRedstoneWireLogic.shouldConnectToDiagonal(worldSource, x, y + 1, z - 1, -1, Side.BOTTOM)) {
-					negZShouldConnectTo = true;
-				}
-
-				if (worldSource.isBlockNormalCube(x, y, z + 1) && AdditionalRedstoneWireLogic.shouldConnectToDiagonal(worldSource, x, y + 1, z + 1, -1, Side.BOTTOM)) {
-					posZShouldConnectTo = true;
-				}
-			}
-
+	@Definition(id = "negZShouldConnectTo", local = @Local(type = boolean.class, name = "negZShouldConnectTo"))
+	@Expression("negZShouldConnectTo")
+	@Inject(method = "getSignal", at = @At("MIXINEXTRAS:EXPRESSION"), cancellable = true)
+	private void fixRedirections(WorldSource worldSource, int x, int y, int z, Side side, CallbackInfoReturnable<Boolean> cir, @Local(name = "posXShouldConnectTo") boolean posXShouldConnectTo, @Local(name = "negXShouldConnectTo") boolean negXShouldConnectTo, @Local(name = "posZShouldConnectTo") boolean posZShouldConnectTo, @Local(name = "negZShouldConnectTo") boolean negZShouldConnectTo) {
 		boolean isXConnected = posXShouldConnectTo || negXShouldConnectTo;
 		boolean isZConnected = posZShouldConnectTo || negZShouldConnectTo;
 
 		// Refactor + Patch to make redirection work as intended
-		return !isZConnected && !isXConnected && side.getAxis() != Axis.Y // Default single dust
+		cir.setReturnValue(!isZConnected && !isXConnected && side.getAxis() != Axis.Y // Default single dust
 			// When the signal request comes from a block that dust connects to (usually power sources)
 			|| side == Side.SOUTH && negZShouldConnectTo
 			|| side == Side.NORTH && posZShouldConnectTo
@@ -75,8 +48,7 @@ public abstract class BlockLogicWireRedstoneMixin {
 			|| side == Side.NORTH && negZShouldConnectTo && !isXConnected
 			|| side == Side.SOUTH && posZShouldConnectTo && !isXConnected
 			|| side == Side.WEST && negXShouldConnectTo && !isZConnected
-			|| side == Side.EAST && posXShouldConnectTo && !isZConnected;
-		}
+			|| side == Side.EAST && posXShouldConnectTo && !isZConnected);
 	}
 	// Connect to both the front and back of the repeater, instead of only the back.
 	@Inject(method = "shouldConnectTo", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/world/WorldSource;getBlockMetadata(III)I", ordinal = 1), cancellable = true)

--- a/src/main/java/com/rikaisan/mixin/BlockLogicWireRedstoneMixin.java
+++ b/src/main/java/com/rikaisan/mixin/BlockLogicWireRedstoneMixin.java
@@ -49,10 +49,12 @@ public abstract class BlockLogicWireRedstoneMixin {
 			|| side == Side.WEST && negXShouldConnectTo && !isZConnected
 			|| side == Side.EAST && posXShouldConnectTo && !isZConnected);
 	}
+	
 	@ModifyExpressionValue(method = "shouldConnectTo", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/block/Block;isSignalSource()Z"))
 	private static boolean dontConnectRedstonePumpkin(boolean original, @Local(name = "blockId") int blockId) {
 		return original && blockId != Blocks.PUMPKIN_REDSTONE.id();
 	}
+	
 	/// Connect to both the front and back of the repeater, instead of only the back.
 	@Inject(method = "shouldConnectTo", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/world/WorldSource;getBlockMetadata(III)I", ordinal = 1), cancellable = true)
 	private static void connectToFrontBackRepeater(WorldSource worldSource, int x, int y, int z, int data, CallbackInfoReturnable<Boolean> cir) {

--- a/src/main/java/com/rikaisan/mixin/BlockLogicWireRedstoneMixin.java
+++ b/src/main/java/com/rikaisan/mixin/BlockLogicWireRedstoneMixin.java
@@ -22,7 +22,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(value = BlockLogicWireRedstone.class, remap = false)
 public abstract class BlockLogicWireRedstoneMixin {
 
-
+	/// Fix for vertically diagonal signal sources, to make behaviour match modern vanilla redstone connections
 	@WrapOperation(method = "getSignal", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/block/BlockLogicWireRedstone;shouldConnectTo(Lnet/minecraft/core/world/WorldSource;IIII)Z"))
 	private boolean fixDiagonal(WorldSource worldSource, int x, int y, int z, int data, Operation<Boolean> original, @Local(name = "y") int originalY) {
 		if(y == originalY - 1) return AdditionalRedstoneWireLogic.shouldConnectToDiagonal(worldSource, x, y, z, data, Side.TOP);
@@ -30,14 +30,13 @@ public abstract class BlockLogicWireRedstoneMixin {
 		return original.call(worldSource, x, y, z, data);
 	}
 
+	/// Refactor + Patch to make redirection work as intended
 	@Definition(id = "negZShouldConnectTo", local = @Local(type = boolean.class, name = "negZShouldConnectTo"))
 	@Expression("negZShouldConnectTo")
 	@Inject(method = "getSignal", at = @At(value = "MIXINEXTRAS:EXPRESSION", ordinal = 0), cancellable = true)
 	private void fixRedirections(WorldSource worldSource, int x, int y, int z, Side side, CallbackInfoReturnable<Boolean> cir, @Local(name = "posXShouldConnectTo") boolean posXShouldConnectTo, @Local(name = "negXShouldConnectTo") boolean negXShouldConnectTo, @Local(name = "posZShouldConnectTo") boolean posZShouldConnectTo, @Local(name = "negZShouldConnectTo") boolean negZShouldConnectTo) {
 		boolean isXConnected = posXShouldConnectTo || negXShouldConnectTo;
 		boolean isZConnected = posZShouldConnectTo || negZShouldConnectTo;
-
-		// Refactor + Patch to make redirection work as intended
 		cir.setReturnValue(!isZConnected && !isXConnected && side.getAxis() != Axis.Y // Default single dust
 			// When the signal request comes from a block that dust connects to (usually power sources)
 			|| side == Side.SOUTH && negZShouldConnectTo
@@ -50,7 +49,7 @@ public abstract class BlockLogicWireRedstoneMixin {
 			|| side == Side.WEST && negXShouldConnectTo && !isZConnected
 			|| side == Side.EAST && posXShouldConnectTo && !isZConnected);
 	}
-	// Connect to both the front and back of the repeater, instead of only the back.
+	/// Connect to both the front and back of the repeater, instead of only the back.
 	@Inject(method = "shouldConnectTo", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/world/WorldSource;getBlockMetadata(III)I", ordinal = 1), cancellable = true)
 	private static void connectToFrontBackRepeater(WorldSource worldSource, int x, int y, int z, int data, CallbackInfoReturnable<Boolean> cir) {
 		// Get the requested side.
@@ -60,8 +59,8 @@ public abstract class BlockLogicWireRedstoneMixin {
 		cir.setReturnValue(target == source || target == source.getOpposite());
 	}
 
-	// Required for setting the repeater to be a signal source.
-	// Otherwise, connectToFrontBackRepeater will not be called, and redstone will redirect to all sides of the repeater.
+	/// Required for setting the repeater to be a signal source.
+	/// Otherwise, connectToFrontBackRepeater will not be called, and redstone will redirect to all sides of the repeater.
 	@Redirect(method = "shouldConnectTo", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/block/Block;isSignalSource()Z"))
 	private static boolean dontConnectToAllRepeaterSides(Block<?> instance) {
 		if(instance == Blocks.REPEATER_IDLE || instance == Blocks.REPEATER_ACTIVE) return false;

--- a/src/main/java/com/rikaisan/mixin/BlockLogicWireRedstoneMixin.java
+++ b/src/main/java/com/rikaisan/mixin/BlockLogicWireRedstoneMixin.java
@@ -2,23 +2,24 @@ package com.rikaisan.mixin;
 
 import com.llamalad7.mixinextras.expression.Definition;
 import com.llamalad7.mixinextras.expression.Expression;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
 import com.rikaisan.AdditionalRedstoneWireLogic;
-import net.minecraft.core.block.Block;
 import net.minecraft.core.block.BlockLogicBed;
 import net.minecraft.core.block.BlockLogicWireRedstone;
 import net.minecraft.core.block.Blocks;
 import net.minecraft.core.util.helper.Axis;
 import net.minecraft.core.util.helper.Side;
 import net.minecraft.core.world.WorldSource;
+import org.spongepowered.asm.mixin.Debug;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+@Debug(export = true)
 @Mixin(value = BlockLogicWireRedstone.class, remap = false)
 public abstract class BlockLogicWireRedstoneMixin {
 
@@ -49,6 +50,10 @@ public abstract class BlockLogicWireRedstoneMixin {
 			|| side == Side.WEST && negXShouldConnectTo && !isZConnected
 			|| side == Side.EAST && posXShouldConnectTo && !isZConnected);
 	}
+	@ModifyExpressionValue(method = "shouldConnectTo", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/block/Block;isSignalSource()Z"))
+	private static boolean dontConnectRedstonePumpkin(boolean original, @Local(name = "blockId") int blockId) {
+		return original && blockId != Blocks.PUMPKIN_REDSTONE.id();
+	}
 	/// Connect to both the front and back of the repeater, instead of only the back.
 	@Inject(method = "shouldConnectTo", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/world/WorldSource;getBlockMetadata(III)I", ordinal = 1), cancellable = true)
 	private static void connectToFrontBackRepeater(WorldSource worldSource, int x, int y, int z, int data, CallbackInfoReturnable<Boolean> cir) {
@@ -61,9 +66,8 @@ public abstract class BlockLogicWireRedstoneMixin {
 
 	/// Required for setting the repeater to be a signal source.
 	/// Otherwise, connectToFrontBackRepeater will not be called, and redstone will redirect to all sides of the repeater.
-	@Redirect(method = "shouldConnectTo", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/block/Block;isSignalSource()Z"))
-	private static boolean dontConnectToAllRepeaterSides(Block<?> instance) {
-		if(instance == Blocks.REPEATER_IDLE || instance == Blocks.REPEATER_ACTIVE) return false;
-		return instance.isSignalSource();
+	@ModifyExpressionValue(method = "shouldConnectTo", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/block/Block;isSignalSource()Z"))
+	private static boolean dontConnectToAllRepeaterSides(boolean original, @Local(name = "blockId") int blockId) {
+		return original && blockId != Blocks.REPEATER_IDLE.id() && blockId != Blocks.REPEATER_ACTIVE.id();
 	}
 }

--- a/src/main/java/com/rikaisan/mixin/BlockModelWireRedstoneMixin.java
+++ b/src/main/java/com/rikaisan/mixin/BlockModelWireRedstoneMixin.java
@@ -1,7 +1,5 @@
 package com.rikaisan.mixin;
 
-import com.llamalad7.mixinextras.expression.Definition;
-import com.llamalad7.mixinextras.expression.Expression;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;

--- a/src/main/java/com/rikaisan/mixin/BlockModelWireRedstoneMixin.java
+++ b/src/main/java/com/rikaisan/mixin/BlockModelWireRedstoneMixin.java
@@ -24,7 +24,7 @@ public abstract class BlockModelWireRedstoneMixin<T extends BlockLogic> extends 
 	}
 
 	@WrapOperation(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/block/BlockLogicWireRedstone;shouldConnectTo(Lnet/minecraft/core/world/WorldSource;IIII)Z"))
-	private boolean a(WorldSource worldSource, int x, int y, int z, int data, Operation<Boolean> original, @Local(name = "y") int originalY) {
+	private boolean fixDiagonal(WorldSource worldSource, int x, int y, int z, int data, Operation<Boolean> original, @Local(name = "y") int originalY) {
 		if(y == originalY - 1) return AdditionalRedstoneWireLogic.shouldConnectToDiagonal(worldSource, x, y, z, data, Side.TOP);
 		if(y == originalY + 1) return AdditionalRedstoneWireLogic.shouldConnectToDiagonal(worldSource, x, y, z, data, Side.BOTTOM);
 		return original.call(worldSource, x, y, z, data);

--- a/src/main/java/com/rikaisan/mixin/BlockModelWireRedstoneMixin.java
+++ b/src/main/java/com/rikaisan/mixin/BlockModelWireRedstoneMixin.java
@@ -23,6 +23,7 @@ public abstract class BlockModelWireRedstoneMixin<T extends BlockLogic> extends 
 		super(block);
 	}
 
+	/// Fix for vertically diagonal signal sources, to make behaviour match modern vanilla redstone connections
 	@WrapOperation(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/block/BlockLogicWireRedstone;shouldConnectTo(Lnet/minecraft/core/world/WorldSource;IIII)Z"))
 	private boolean fixDiagonal(WorldSource worldSource, int x, int y, int z, int data, Operation<Boolean> original, @Local(name = "y") int originalY) {
 		if(y == originalY - 1) return AdditionalRedstoneWireLogic.shouldConnectToDiagonal(worldSource, x, y, z, data, Side.TOP);

--- a/src/main/java/com/rikaisan/mixin/BlockModelWireRedstoneMixin.java
+++ b/src/main/java/com/rikaisan/mixin/BlockModelWireRedstoneMixin.java
@@ -1,5 +1,10 @@
 package com.rikaisan.mixin;
 
+import com.llamalad7.mixinextras.expression.Definition;
+import com.llamalad7.mixinextras.expression.Expression;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
 import com.rikaisan.AdditionalRedstoneWireLogic;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
@@ -11,8 +16,6 @@ import net.minecraft.core.util.helper.Side;
 import net.minecraft.core.world.WorldSource;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
-import org.spongepowered.asm.mixin.injection.Slice;
 
 @Environment(EnvType.CLIENT)
 @Mixin(value = BlockModelWireRedstone.class, remap = false)
@@ -22,67 +25,10 @@ public abstract class BlockModelWireRedstoneMixin<T extends BlockLogic> extends 
 		super(block);
 	}
 
-	@Redirect(
-		method = "render(Lnet/minecraft/client/render/tessellator/Tessellator;III)Z",
-		at = @At(
-			value = "INVOKE",
-			target = "Lnet/minecraft/core/block/BlockLogicWireRedstone;shouldConnectTo(Lnet/minecraft/core/world/WorldSource;IIII)Z",
-			ordinal = 1
-		))
-	public boolean shouldConnectToWest(WorldSource worldSource, int x, int y, int z, int data) {
-		return AdditionalRedstoneWireLogic.shouldConnectToDiagonal(worldSource, x, y, z, data, Side.TOP);
-	}
-	@Redirect(
-		method = "render(Lnet/minecraft/client/render/tessellator/Tessellator;III)Z",
-		at = @At(
-			value = "INVOKE",
-			target = "Lnet/minecraft/core/block/BlockLogicWireRedstone;shouldConnectTo(Lnet/minecraft/core/world/WorldSource;IIII)Z",
-			ordinal = 3
-		))
-	public boolean shouldConnectToEast(WorldSource worldSource, int x, int y, int z, int data) {
-		return AdditionalRedstoneWireLogic.shouldConnectToDiagonal(worldSource, x, y, z, data, Side.TOP);
-	}
-	@Redirect(
-		method = "render(Lnet/minecraft/client/render/tessellator/Tessellator;III)Z",
-		at = @At(
-			value = "INVOKE",
-			target = "Lnet/minecraft/core/block/BlockLogicWireRedstone;shouldConnectTo(Lnet/minecraft/core/world/WorldSource;IIII)Z",
-			ordinal = 5
-		))
-	public boolean shouldConnectToNorth(WorldSource worldSource, int x, int y, int z, int data) {
-		return AdditionalRedstoneWireLogic.shouldConnectToDiagonal(worldSource, x, y, z, data, Side.TOP);
-	}
-	@Redirect(
-		method = "render(Lnet/minecraft/client/render/tessellator/Tessellator;III)Z",
-		at = @At(
-			value = "INVOKE",
-			target = "Lnet/minecraft/core/block/BlockLogicWireRedstone;shouldConnectTo(Lnet/minecraft/core/world/WorldSource;IIII)Z",
-			ordinal = 7
-		))
-	public boolean shouldConnectToSouth(WorldSource worldSource, int x, int y, int z, int data) {
-		return AdditionalRedstoneWireLogic.shouldConnectToDiagonal(worldSource, x, y, z, data, Side.TOP);
-	}
-
-	@Redirect(
-		method = "render(Lnet/minecraft/client/render/tessellator/Tessellator;III)Z",
-		slice = @Slice(
-			from = @At(
-				value = "INVOKE",
-				target = "Lnet/minecraft/core/block/BlockLogicWireRedstone;shouldConnectTo(Lnet/minecraft/core/world/WorldSource;IIII)Z",
-				ordinal = 8
-			),
-			to = @At(
-				value = "INVOKE",
-				target = "Lnet/minecraft/core/block/BlockLogicWireRedstone;shouldConnectTo(Lnet/minecraft/core/world/WorldSource;IIII)Z",
-				ordinal = 11
-			)
-		),
-		at = @At(
-			value = "INVOKE",
-			target = "Lnet/minecraft/core/block/BlockLogicWireRedstone;shouldConnectTo(Lnet/minecraft/core/world/WorldSource;IIII)Z"
-		)
-	)
-	public boolean shouldConnectToUp(WorldSource worldSource, int x, int y, int z, int data) {
-		return AdditionalRedstoneWireLogic.shouldConnectToDiagonal(worldSource, x, y, z, data, Side.BOTTOM);
+	@WrapOperation(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/block/BlockLogicWireRedstone;shouldConnectTo(Lnet/minecraft/core/world/WorldSource;IIII)Z"))
+	private boolean a(WorldSource worldSource, int x, int y, int z, int data, Operation<Boolean> original, @Local(name = "y") int originalY) {
+		if(y == originalY - 1) return AdditionalRedstoneWireLogic.shouldConnectToDiagonal(worldSource, x, y, z, data, Side.TOP);
+		if(y == originalY + 1) return AdditionalRedstoneWireLogic.shouldConnectToDiagonal(worldSource, x, y, z, data, Side.BOTTOM);
+		return original.call(worldSource, x, y, z, data);
 	}
 }

--- a/src/main/resources/redstonetweaks.mixins.json
+++ b/src/main/resources/redstonetweaks.mixins.json
@@ -1,6 +1,9 @@
 {
   "required": true,
   "minVersion": "0.8",
+  "mixinextras": {
+    "minVersion": "0.5.0-beta.5"
+  },
   "package": "com.rikaisan.mixin",
   "compatibilityLevel": "JAVA_8",
   "mixins": [


### PR DESCRIPTION
Avoids completely overwriting methods, or always cancelling head injects.

In the wire logic, this is done by injecting in front of the if statement (which only uses locals).
This used to be impossible, but has recently been made possible using MixinExtras' `@Expressions`.

The other part of the previously overwritten wire logic, has been replaced with an `@WrapOperation`, and comparing the passed `y` value to the original value in the `getSignal` local variables.

The redstone block's `getDirectSignal` inject has also been replaced with a `@WrapOperation`, to ensure it behaves correctly when the `redstoneBlockHardPower` gamerule is set, and another mod has injected into the `getSignal` function.