### PR TITLE
Prevent repeater flicker on placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A mod to improve BTA! redstone :)
 - Repeaters now properly connect to redstone dust
 - Repeaters now properly soft power some blocks and redstone components
 - Repeaters now send updates when removed
+- Repeaters no longer send a 1 tick pulse when placed next to a powered block
 - Redstone Jack o' lanterns no longer redirect redstone on all sides
 
 ## To-do list

--- a/src/main/java/com/rikaisan/mixin/BlockLogicRepeaterMixin.java
+++ b/src/main/java/com/rikaisan/mixin/BlockLogicRepeaterMixin.java
@@ -1,15 +1,15 @@
 package com.rikaisan.mixin;
 
-import net.minecraft.core.block.Block;
-import net.minecraft.core.block.BlockLogic;
-import net.minecraft.core.block.BlockLogicBed;
-import net.minecraft.core.block.BlockLogicRepeater;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.sugar.Local;
+import net.minecraft.core.block.*;
 import net.minecraft.core.block.material.Material;
 import net.minecraft.core.util.helper.Side;
 import net.minecraft.core.world.World;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
 
-@Mixin(BlockLogicRepeater.class)
+@Mixin(value = BlockLogicRepeater.class, remap = false)
 public abstract class BlockLogicRepeaterMixin extends BlockLogic {
 	public BlockLogicRepeaterMixin(Block<?> block, Material material) {
 		super(block, material);
@@ -29,5 +29,9 @@ public abstract class BlockLogicRepeaterMixin extends BlockLogic {
 		world.notifyBlocksOfNeighborChange(x + front.getOffsetX(), y + front.getOffsetY(), z + front.getOffsetZ(), id());
 		Side back = front.getOpposite();
 		world.notifyBlocksOfNeighborChange(x + back.getOffsetX(), y + back.getOffsetY(), z + back.getOffsetZ(), id());
+	}
+	@ModifyExpressionValue(method = "updateTick", at = @At(value = "FIELD", target = "Lnet/minecraft/core/block/BlockLogicRepeater;isRepeaterPowered:Z", ordinal = 1))
+	private boolean preventPlaceFlicker(boolean original, @Local(name = "flag") boolean flag) {
+		return original || !flag;
 	}
 }

--- a/src/main/java/com/rikaisan/mixin/BlockLogicRepeaterMixin.java
+++ b/src/main/java/com/rikaisan/mixin/BlockLogicRepeaterMixin.java
@@ -30,8 +30,10 @@ public abstract class BlockLogicRepeaterMixin extends BlockLogic {
 		Side back = front.getOpposite();
 		world.notifyBlocksOfNeighborChange(x + back.getOffsetX(), y + back.getOffsetY(), z + back.getOffsetZ(), id());
 	}
+
+	// Fix the 1 tick pulse when placing a repeater next to a powered block
 	@ModifyExpressionValue(method = "updateTick", at = @At(value = "FIELD", target = "Lnet/minecraft/core/block/BlockLogicRepeater;isRepeaterPowered:Z", ordinal = 1))
-	private boolean preventPlaceFlicker(boolean original, @Local(name = "flag") boolean flag) {
+	private boolean checkGettingPowered(boolean original, @Local(name = "flag") boolean flag) {
 		return original || !flag;
 	}
 }

--- a/src/main/java/com/rikaisan/mixin/WorldMixin.java
+++ b/src/main/java/com/rikaisan/mixin/WorldMixin.java
@@ -15,7 +15,7 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 public abstract class WorldMixin {
 
 	@Redirect(method = "getSignal(IIILnet/minecraft/core/util/helper/Side;)Z", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/block/Block;getSignal(Lnet/minecraft/core/world/WorldSource;IIILnet/minecraft/core/util/helper/Side;)Z"))
-	public boolean getSignal(Block<?> instance, WorldSource worldSource, int x, int y, int z, Side side) {
+	private boolean getSignal(Block<?> instance, WorldSource worldSource, int x, int y, int z, Side side) {
 		if (instance == Blocks.PUMPKIN_REDSTONE) {
 			return pumpkinHasDirectSignal(x, y, z) || instance.getSignal(worldSource, x, y, z, side);
 		} else {


### PR DESCRIPTION
Prevent a short flicker of redstone signal when placing a repeater with a signal source on the south side.