### PR TITLE
Fix the powered state of doors after placement

### DIFF
--- a/src/main/java/com/rikaisan/AdditionalDoorTypeLogic.java
+++ b/src/main/java/com/rikaisan/AdditionalDoorTypeLogic.java
@@ -1,5 +1,7 @@
 package com.rikaisan;
 
+import net.minecraft.core.world.World;
+
 public class AdditionalDoorTypeLogic {
 	public static final int MASK_POWERED = 0b10000;
 	public static boolean isPowered(int metadata) {
@@ -7,5 +9,11 @@ public class AdditionalDoorTypeLogic {
 	}
 	public static int setPowered(int metadata, boolean isPowered) {
 		return isPowered ? metadata | MASK_POWERED : metadata & ~MASK_POWERED;
+	}
+	public static int savePowered(World world, int x, int y, int z, int meta, boolean isPowered, boolean isPreviouslyPowered) {
+		if(isPowered == isPreviouslyPowered) return meta;
+		meta = AdditionalDoorTypeLogic.setPowered(meta, isPowered);
+		world.setBlockMetadata(x, y, z, meta);
+		return meta;
 	}
 }

--- a/src/main/java/com/rikaisan/AdditionalDoorTypeLogic.java
+++ b/src/main/java/com/rikaisan/AdditionalDoorTypeLogic.java
@@ -4,14 +4,17 @@ import net.minecraft.core.world.World;
 
 public class AdditionalDoorTypeLogic {
 	public static final int MASK_POWERED = 0b10000;
+
 	public static boolean isPowered(int metadata) {
 		return (metadata & MASK_POWERED) != 0;
 	}
+
 	public static int setPowered(int metadata, boolean isPowered) {
 		return isPowered ? metadata | MASK_POWERED : metadata & ~MASK_POWERED;
 	}
+
 	public static int savePowered(World world, int x, int y, int z, int meta, boolean isPowered, boolean isPreviouslyPowered) {
-		if(isPowered == isPreviouslyPowered) return meta;
+		if (isPowered == isPreviouslyPowered) return meta;
 		meta = AdditionalDoorTypeLogic.setPowered(meta, isPowered);
 		world.setBlockMetadata(x, y, z, meta);
 		return meta;

--- a/src/main/java/com/rikaisan/mixin/block/logic/BlockLogicDoorMixin.java
+++ b/src/main/java/com/rikaisan/mixin/block/logic/BlockLogicDoorMixin.java
@@ -9,6 +9,7 @@ import com.llamalad7.mixinextras.sugar.ref.LocalBooleanRef;
 import com.llamalad7.mixinextras.sugar.ref.LocalIntRef;
 import com.rikaisan.AdditionalDoorTypeLogic;
 import net.minecraft.core.block.BlockLogicDoor;
+import net.minecraft.core.util.helper.Side;
 import net.minecraft.core.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -17,12 +18,16 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(value = BlockLogicDoor.class, remap = false)
 public class BlockLogicDoorMixin {
+	@Inject(method = "onBlockPlacedOnSide", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/world/World;setBlockMetadataWithNotify(IIII)V"))
+	private void loadPreviouslyPoweredBlockPlaced(World world, int x, int y, int z, Side side, double xPlaced, double yPlaced, CallbackInfo ci, @Local(name = "meta") LocalIntRef meta) {
+		boolean isPreviouslyPowered = AdditionalDoorTypeLogic.isPowered(meta.get());
+		meta.set(AdditionalDoorTypeLogic.savePowered(world, x, y, z, meta.get(), true, isPreviouslyPowered));
+	}
+
 	@Inject(method = "onPoweredBlockChange", at = @At(value = "INVOKE", target = "Lnet/minecraft/core/world/World;getBlockMetadata(III)I", ordinal = 1, shift = At.Shift.AFTER))
-	private void savePowered(World world, int x, int y, int z, boolean isPowered, CallbackInfo ci, @Local(name = "meta") LocalIntRef meta, @Share("isPreviouslyPowered") LocalBooleanRef isPreviouslyPowered) {
+	private void loadPreviouslyPoweredBlockChanged(World world, int x, int y, int z, boolean isPowered, CallbackInfo ci, @Local(name = "meta") LocalIntRef meta, @Share("isPreviouslyPowered") LocalBooleanRef isPreviouslyPowered) {
 		isPreviouslyPowered.set(AdditionalDoorTypeLogic.isPowered(meta.get()));
-		if(isPowered == isPreviouslyPowered.get()) return;
-		meta.set(AdditionalDoorTypeLogic.setPowered(meta.get(), isPowered));
-		world.setBlockMetadata(x, y, z, meta.get());
+		meta.set(AdditionalDoorTypeLogic.savePowered(world, x, y, z, meta.get(), isPowered, isPreviouslyPowered.get()));
 	}
 
 	@Definition(id = "isOpen", local = @Local(type = boolean.class, ordinal = 1))

--- a/src/main/java/com/rikaisan/mixin/block/logic/BlockLogicTrapDoorMixin.java
+++ b/src/main/java/com/rikaisan/mixin/block/logic/BlockLogicTrapDoorMixin.java
@@ -9,6 +9,7 @@ import com.llamalad7.mixinextras.sugar.ref.LocalBooleanRef;
 import com.llamalad7.mixinextras.sugar.ref.LocalIntRef;
 import com.rikaisan.AdditionalDoorTypeLogic;
 import net.minecraft.core.block.BlockLogicTrapDoor;
+import net.minecraft.core.util.helper.Side;
 import net.minecraft.core.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -22,11 +23,18 @@ public class BlockLogicTrapDoorMixin {
 	@Definition(id = "isPowered", local = @Local(type = boolean.class, ordinal = 1))
 	@Expression("isOpened != isPowered")
 	@Inject(method = "onNeighborBlockChange", at = @At("MIXINEXTRAS:EXPRESSION"))
-	private void savePowered(World world, int x, int y, int z, int blockId, CallbackInfo ci, @Local(name = "meta") LocalIntRef meta, @Local(name = "isPowered") boolean isPowered, @Share("isPreviouslyPowered") LocalBooleanRef isPreviouslyPowered) {
+	private void loadPreviouslyPoweredNeighborUpdate(World world, int x, int y, int z, int blockId, CallbackInfo ci, @Local(name = "meta") LocalIntRef meta, @Local(name = "isPowered") boolean isPowered, @Share("isPreviouslyPowered") LocalBooleanRef isPreviouslyPowered) {
 		isPreviouslyPowered.set(AdditionalDoorTypeLogic.isPowered(meta.get()));
-		if(isPowered == isPreviouslyPowered.get()) return;
-		meta.set(AdditionalDoorTypeLogic.setPowered(meta.get(), isPowered));
-		world.setBlockMetadata(x, y, z, meta.get());
+		meta.set(AdditionalDoorTypeLogic.savePowered(world, x, y, z, meta.get(), isPowered, isPreviouslyPowered.get()));
+	}
+
+	@Definition(id = "isOpened", local = @Local(type = boolean.class, ordinal = 0))
+	@Definition(id = "isPowered", local = @Local(type = boolean.class, ordinal = 1))
+	@Expression("isOpened != isPowered")
+	@Inject(method = "onBlockPlacedOnSide", at = @At("MIXINEXTRAS:EXPRESSION"))
+	private void loadPreviouslyPoweredBlockPlaced(World world, int x, int y, int z, Side side, double xPlaced, double yPlaced, CallbackInfo ci, @Local(name = "meta") LocalIntRef meta, @Local(name = "isPowered") boolean isPowered, @Share("isPreviouslyPowered") LocalBooleanRef isPreviouslyPowered) {
+		isPreviouslyPowered.set(AdditionalDoorTypeLogic.isPowered(meta.get()));
+		meta.set(AdditionalDoorTypeLogic.savePowered(world, x, y, z, meta.get(), isPowered, isPreviouslyPowered.get()));
 	}
 
 	@Definition(id = "isOpened", local = @Local(type = boolean.class, ordinal = 0))


### PR DESCRIPTION
Fix doors and trapdoors not updating their powered state after being placed next to an active signal source